### PR TITLE
Testcase attachment permissions seem both broken and unessesary

### DIFF
--- a/tcms/testcases/views.py
+++ b/tcms/testcases/views.py
@@ -1311,7 +1311,7 @@ def category(request):
     return func()
 
 
-@permission_required('testcases.add_testcaseattachment')
+@permission_required('testcases.add_testcasecomponent')
 def attachment(request, case_id, template_name='case/attachment.html'):
     """Manage test case attachments"""
 


### PR DESCRIPTION
Changing the permission to the standard add testcase component because its currently broken and I have no idea why you would want permissions that granular.