### PR TITLE
Cad 3785 add dashboard item to link test runs per user

### DIFF
--- a/tcms/core/views.py
+++ b/tcms/core/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import requires_csrf_token
 
 from tcms.testplans.models import TestPlan
-from tcms.testruns.models import TestRun
+from tcms.testruns.models import TestRun, TestCaseRun
 
 
 @require_GET
@@ -27,7 +27,14 @@ def dashboard(request):
     test_plans_disable_count = test_plans.filter(is_active=False).count()
 
     test_runs = TestRun.objects.filter(
-        Q(manager=request.user) | Q(default_tester=request.user),
+        stop_date__isnull=True,
+    ).order_by('-run_id')
+
+    # my_active_tc_runs = TestCaseRun.objects.filter(
+    #     Q(assignee=request.user) and Q(run__in=active_test_runs)
+    # )
+    active_tc_runs = TestRun.objects.filter(
+        Q(case_run__assignee=request.user) | Q(manager=request.user),
         stop_date__isnull=True,
     ).order_by('-run_id')
 
@@ -37,6 +44,7 @@ def dashboard(request):
         'last_15_test_plans': test_plans.filter(is_active=True)[:15],
 
         'last_15_test_runs': test_runs[:15],
+        'active_tc_runs': active_tc_runs,
 
         'test_runs_count': test_runs.count(),
     }

--- a/tcms/core/views.py
+++ b/tcms/core/views.py
@@ -8,7 +8,7 @@ from django.contrib.auth.decorators import login_required
 from django.views.decorators.csrf import requires_csrf_token
 
 from tcms.testplans.models import TestPlan
-from tcms.testruns.models import TestRun, TestCaseRun
+from tcms.testruns.models import TestRun
 
 
 @require_GET
@@ -30,9 +30,6 @@ def dashboard(request):
         stop_date__isnull=True,
     ).order_by('-run_id')
 
-    # my_active_tc_runs = TestCaseRun.objects.filter(
-    #     Q(assignee=request.user) and Q(run__in=active_test_runs)
-    # )
     active_tc_runs = TestRun.objects.filter(
         Q(case_run__assignee=request.user) | Q(manager=request.user),
         stop_date__isnull=True,

--- a/tcms/templates/dashboard.html
+++ b/tcms/templates/dashboard.html
@@ -4,8 +4,9 @@
 
 {% block contents %}
 <div class="container-fluid container-cards-pf">
+<div class="row">
     <div class="panel panel-default col-sm-12 col-md-5 col-lg-5" style="padding:0; margin-right:1%">
-        <div class="panel-heading"><strong>{% trans "Test executions" %}</strong></div>
+        <div class="panel-heading"><strong>{% trans "Active Test Executions" %}</strong></div>
         <table class="table table-striped">
             <tbody>
             {% for test_run in last_15_test_runs %}
@@ -24,7 +25,7 @@
         <div class="panel-footer">
             {% if test_runs_count %}
                 {% blocktrans with total_count=test_runs_count count=last_15_test_runs|length %}
-                {{ total_count }} TestRun(s) assigned to you need to be executed.
+                {{ total_count }} TestRun(s) need to be executed.
                 Here are the latest {{ count }}.
                 {% endblocktrans %}
 
@@ -32,7 +33,7 @@
                     {% trans "SEE ALL" %}
                 </a>
             {% else %}
-                {% trans "There are no TestRun(s) assigned to you" %}
+                {% trans "There are active TestRuns" %}
             {% endif %}
         </div>
     </div> <!-- /panel -->
@@ -74,7 +75,7 @@
                 Here are the latest {{ count }}.
                 {% endblocktrans %}
 
-                <a href="{% url "plans-search" %}?author__username__startswith={{ user.username }}">
+                <a href="{% url "plans-search" %}?author__username__startswith={{ user.username| iriencode }}">
                     {% trans "SEE ALL" %}
                 </a>
             {% else %}
@@ -82,6 +83,42 @@
             {% endif %}
         </div>
     </div> <!-- /panel -->
+</div>
+    <div class="row">
+            <div class="panel panel-default col-sm-12 col-md-5 col-lg-5" style="padding:0; margin-right:1%">
+            <div class="panel-heading"><strong>{% trans "Test runs with cases assigned to you" %}</strong></div>
+            <table class="table table-striped">
+                <tbody>
+                {% for test_run in active_tc_runs %}
+                    <tr>
+                        <td>
+                            {% include "run/status_progress_patternfly.html" with stats=test_run.stats_caseruns_status %}
+                        </td>
+                        <td>
+                            <a href="{% url "testruns-get" test_run.run_id %}?assignee__email__startswith={{ user.username|iriencode }}">{{ test_run.summary }}</a>
+                            <div>{% trans "Started at" %} {{ test_run.start_date }}</div>
+                        </td>
+                    </tr>
+                {% endfor %}
+                </tbody>
+            </table>
+            <div class="panel-footer">
+                {% if test_runs_count %}
+                    {% blocktrans with total_count=test_runs_count count=active_tc_runs|length %}
+                    {{ total_count }} TestRun(s) have cases assigned to you need to be executed.
+                    Here are the latest {{ count }}.
+                    {% endblocktrans %}
+
+                    <a href="{% url "testruns-search" %}?assignee__email__startswith={{ user.username|iriencode }}">
+                        {% trans "SEE ALL" %}
+                    </a>
+                {% else %}
+                    {% trans "There are no TestRun(s) assigned to you" %}
+                {% endif %}
+            </div>
+        </div> <!-- /panel -->
+    </div>
+
 
 </div><!-- /container -->
 {% endblock %}

--- a/tcms/templates/dashboard.html
+++ b/tcms/templates/dashboard.html
@@ -6,7 +6,7 @@
 <div class="container-fluid container-cards-pf">
 <div class="row">
     <div class="panel panel-default col-sm-12 col-md-5 col-lg-5" style="padding:0; margin-right:1%">
-        <div class="panel-heading"><strong>{% trans "Active Test Executions" %}</strong></div>
+        <div class="panel-heading"><strong>{% trans "Active Test Runs" %}</strong></div>
         <table class="table table-striped">
             <tbody>
             {% for test_run in last_15_test_runs %}
@@ -95,7 +95,7 @@
                             {% include "run/status_progress_patternfly.html" with stats=test_run.stats_caseruns_status %}
                         </td>
                         <td>
-                            <a href="{% url "testruns-get" test_run.run_id %}?assignee__email__startswith={{ user.username|iriencode }}">{{ test_run.summary }}</a>
+                            <a href="{% url "testruns-get" test_run.run_id %}?assignee__email__startswith={{ user.email|iriencode }}">{{ test_run.summary }}</a>
                             <div>{% trans "Started at" %} {{ test_run.start_date }}</div>
                         </td>
                     </tr>
@@ -109,7 +109,7 @@
                     Here are the latest {{ count }}.
                     {% endblocktrans %}
 
-                    <a href="{% url "testruns-search" %}?assignee__email__startswith={{ user.username|iriencode }}">
+                    <a href="{% url "testruns-search" %}?assignee__email__startswith={{ user.email|iriencode }}">
                         {% trans "SEE ALL" %}
                     </a>
                 {% else %}


### PR DESCRIPTION
- Changed existing test run panel to show the top 15 active test runs instead of top 15 test runs assigned to you
- Added new panel on dashboard that shows test runs that have test cases assigned to you
- New panel links to a view that is filtered by test case runs assigned to you
<img width="1680" alt="screen shot 2018-11-01 at 10 16 19 am" src="https://user-images.githubusercontent.com/1276341/47857274-9a2e0780-ddbf-11e8-9075-5f8a00314714.png">
<img width="1678" alt="screen shot 2018-11-01 at 10 16 48 am" src="https://user-images.githubusercontent.com/1276341/47857275-9a2e0780-ddbf-11e8-8f09-34c0e0bdb7f6.png">
<img width="1677" alt="screen shot 2018-11-01 at 10 16 59 am" src="https://user-images.githubusercontent.com/1276341/47857276-9a2e0780-ddbf-11e8-9ee4-ef818c3eef29.png">


