### PR TITLE
Kiwi bug fixes

### DIFF
--- a/tcms/issues/tests.py
+++ b/tcms/issues/tests.py
@@ -4,6 +4,8 @@ from django.test import TestCase
 from django.urls import reverse
 from .models import Project, IssueType, Issue, Organization
 from .admin import AtlassianRequests
+from .webhooks import *
+from copy import deepcopy
 import json
 
 
@@ -398,3 +400,194 @@ class TestIssueSync(TestCase):
             issue2 = Issue.objects.get(jid=10001)
             self.assertEqual(issue1.jira_key, 'EX')
             self.assertEqual(issue2.jira_key, 'ABC')
+
+
+class TestWebhooks(TestCase):
+
+    @classmethod
+    def setUpTestData(cls):
+        # Create an existing project to save against
+        project = Project(jid=10001, key="TEST", name="Test Project")
+        project.save()
+        # Project only takes the story issue type
+        issue_type = IssueType(project=project, name="Story", jid=1, icon_url="http://notaurl.com/img")
+        issue_type.save()
+        # Create an existing issue for update cases
+        cls.issue = Issue(
+            jid=10001,
+            link="https://atlassian.com/myissue",
+            jira_key="TEST-1",
+            fixVersions="[https://atlassian.com/fixversion]",
+            summary="Summary of My Issue",
+            assignee="tester1",
+            issue_type=issue_type,
+            project=project,
+            iss_updated="2018-11-14T06:02:01.639+0000",
+            iss_created="2018-11-14T06:02:01.639+0000",
+        )
+        cls.issue.save()
+
+        cls.base_test_issue = {
+            "issue": {
+                    "self": "http://you.atlassian.net/rest/api/2/project/EX",
+                    "id": "10001",
+                    "key": "TEST-1",
+                    "name": "Example",
+                    "avatarUrls": {
+                        "48x48": "http://you.atlassian.net/secure/projectavatar?size=large&pid=10000",
+                        "24x24": "http://you.atlassian.net/secure/projectavatar?size=small&pid=10000",
+                        "16x16": "http://you.atlassian.net/secure/projectavatar?size=xsmall&pid=10000",
+                        "32x32": "http://you.atlassian.net/secure/projectavatar?size=medium&pid=10000"
+                    },
+                    "projectCategory": {
+                        "self": "http://you.atlassian.net/rest/api/2/projectCategory/10000",
+                        "id": "10000",
+                        "name": "FIRST",
+                        "description": "First Project Category"
+                    },
+                    "simplified": False,
+                    "style": "classic",
+                    "fields": {
+                        "project": {
+                            "self": "http://your-domain.atlassian.net/rest/api/2/project/EX",
+                            "id": "10001",
+                            "key": "TEST",
+                            "description": "This project was created as an example for REST.",
+                            "lead": {
+                                "self": "http://your-domain.atlassian.net/rest/api/2/user?username=mia",
+                                "key": "mia",
+                                "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+                                "name": "mia",
+                                "avatarUrls": {
+                                    "48x48": "http://your-domain.atlassian.net/secure/useravatar?size=large&ownerId=mia",
+                                    "24x24": "http://your-domain.atlassian.net/secure/useravatar?size=small&ownerId=mia",
+                                    "16x16": "http://your-domain.atlassian.net/secure/useravatar?size=xsmall&ownerId=mia",
+                                    "32x32": "http://your-domain.atlassian.net/secure/useravatar?size=medium&ownerId=mia"
+                                },
+                                "displayName": "Mia Krystof",
+                                "active": False
+                            }
+                        },
+                        "issuetype": {
+                          "self": "http://your-domain.atlassian.net/rest/api/2/issueType/1",
+                          "id": "1",
+                          "description": "A task that needs to be done.",
+                          "iconUrl": "http://your-domain.atlassian.net//secure/viewavatar?size=xsmall&avatarId=10299&avatarType=issuetype\",",
+                          "name": "Story",
+                          "subtask": False,
+                          "avatarId": 1
+                        },
+                        "fixVersions": ['1.2.3'],
+                        "summary": "A test issue",
+                        "assignee": "Matt Damon",
+                        "updated": '2018-11-14T06:02:01.639+0000',
+                        "created": '2018-11-14T06:02:01.639+0000',
+
+                    }
+            }
+        }
+
+    def test_update_issue(self):
+        data = deepcopy(self.base_test_issue)
+        update_issue(data)
+        updated_issue = Issue.objects.get(jid=10001)
+        # Assert the issue has been updated
+        self.assertEqual("A test issue", updated_issue.summary)
+
+    def test_update_issue_no_exist(self):
+        data = deepcopy(self.base_test_issue)
+        data['issue']['id'] = "10002"
+        update_issue(data)
+        # Assert the issue was created
+        self.assertTrue(Issue.objects.get(jid=10002))
+
+    def test_update_issue_no_issue_type(self):
+        data = deepcopy(self.base_test_issue)
+        data['issue']['fields']['issuetype'] = {
+                          "self": "http://your-domain.atlassian.net/rest/api/2/issueType/2",
+                          "id": "2",
+                          "description": "A task that needs to be done.",
+                          "iconUrl": "http://your-domain.atlassian.net//secure/viewavatar?size=xsmall&avatarId=10299&avatarType=issuetype\",",
+                          "name": "Task",
+                          "subtask": False,
+                          "avatarId": 1
+                        }
+
+        update_issue(data)
+        # Assert the issue was not updated
+        self.assertEqual(self.issue, Issue.objects.get(jid=10001))
+
+    def test_update_issue_no_project(self):
+        data = deepcopy(self.base_test_issue)
+        data['issue']['fields']['project'] = {
+                            "self": "http://your-domain.atlassian.net/rest/api/2/project/EX",
+                            "id": "10002",
+                            "key": "EX",
+                            "description": "This project was created as an example for REST.",
+                            "lead": {
+                                "self": "http://your-domain.atlassian.net/rest/api/2/user?username=mia",
+                                "key": "mia",
+                                "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+                                "name": "mia",
+                                "avatarUrls": {
+                                    "48x48": "http://your-domain.atlassian.net/secure/useravatar?size=large&ownerId=mia",
+                                    "24x24": "http://your-domain.atlassian.net/secure/useravatar?size=small&ownerId=mia",
+                                    "16x16": "http://your-domain.atlassian.net/secure/useravatar?size=xsmall&ownerId=mia",
+                                    "32x32": "http://your-domain.atlassian.net/secure/useravatar?size=medium&ownerId=mia"
+                                },
+                                "displayName": "Mia Krystof",
+                                "active": False
+                            }
+                        }
+        update_issue(data)
+        # Assert the issue was not updated
+        self.assertEqual(self.issue, Issue.objects.get(jid=10001))
+
+    def test_create_issue(self):
+        data = deepcopy(self.base_test_issue)
+        data['issue']["id"] = "10023"
+        create_issue(data)
+        # Assert the issue has been updated
+        self.assertTrue(Issue.objects.get(jid=10023))
+
+    def test_create_issue_no_issue_type(self):
+        data = deepcopy(self.base_test_issue)
+        data['issue']['fields']['issuetype'] = {
+            "self": "http://your-domain.atlassian.net/rest/api/2/issueType/2",
+            "id": "2",
+            "description": "A task that needs to be done.",
+            "iconUrl": "http://your-domain.atlassian.net//secure/viewavatar?size=xsmall&avatarId=10299&avatarType=issuetype\",",
+            "name": "Task",
+            "subtask": False,
+            "avatarId": 1
+        }
+
+        create_issue(data)
+        # Assert the issue was not updated
+        self.assertEqual(self.issue, Issue.objects.get(jid=10001))
+
+    def test_create_issue_no_project(self):
+        data = deepcopy(self.base_test_issue)
+        data['issue']['fields']['project'] = {
+            "self": "http://your-domain.atlassian.net/rest/api/2/project/EX",
+            "id": "10002",
+            "key": "EX",
+            "description": "This project was created as an example for REST.",
+            "lead": {
+                "self": "http://your-domain.atlassian.net/rest/api/2/user?username=mia",
+                "key": "mia",
+                "accountId": "99:27935d01-92a7-4687-8272-a9b8d3b2ae2e",
+                "name": "mia",
+                "avatarUrls": {
+                    "48x48": "http://your-domain.atlassian.net/secure/useravatar?size=large&ownerId=mia",
+                    "24x24": "http://your-domain.atlassian.net/secure/useravatar?size=small&ownerId=mia",
+                    "16x16": "http://your-domain.atlassian.net/secure/useravatar?size=xsmall&ownerId=mia",
+                    "32x32": "http://your-domain.atlassian.net/secure/useravatar?size=medium&ownerId=mia"
+                },
+                "displayName": "Mia Krystof",
+                "active": False
+            }
+        }
+        create_issue(data)
+        # Assert the issue was not updated
+        self.assertEqual(self.issue, Issue.objects.get(jid=10001))

--- a/tcms/issues/views.py
+++ b/tcms/issues/views.py
@@ -11,7 +11,9 @@ from .models import Issue
 @login_not_required
 def issue_linked_test_cases(request):
     jira_key = request.GET.get('issueKey')
-    issue = Issue.objects.get(jira_key=jira_key)
+    issue = Issue.objects.filter(jira_key=jira_key)
+    if not issue:
+        return render(request, 'issues/issue_not_found.html')
     cases = issue.test_cases.all()
     site_url = Site.objects.get_current().domain
     context = {'cases': [], 'site_url': site_url}

--- a/tcms/issues/webhooks.py
+++ b/tcms/issues/webhooks.py
@@ -7,16 +7,30 @@ import logging
 logger = logging.getLogger('django')
 
 
+def _get_issue_type(issue, project):
+    # Use filter because we don't want the exception if get fails
+    issue_type = IssueType.objects.filter(
+        jid=issue['fields']['issuetype']['id'],
+        project=project.id,
+    ).first()
+    if not issue_type:
+        logger.info("Project %s not configured for IssueType %s, skipping %s",
+                    project.name, issue['fields']['issuetype']['name'], issue['key'])
+    return issue_type
+
+
 def create_issue(data):
-    logger.error(data)
     issue = data['issue']
-    project = Project.objects.get(key=issue['fields']['project']['key'])
+    project_key = issue['fields']['project']['key']
+    # Use filter because we don't want the exception if get fails
+    project = Project.objects.filter(key=project_key).first()
     if project:
-        issue_type = IssueType.objects.get(
-            jid=issue['fields']['issuetype']['id'],
-            project=project.id,
-        )
-        Issue.objects.create(
+        issue_type = _get_issue_type(issue, project)
+        if not issue_type:
+            logger.info("%s not configured to save IssueType %s",
+                        project_key, issue['fields']['issuetype']['name'])
+            return HttpResponse('OK')
+        created_issue = Issue.objects.create(
             jid=issue['id'],
             link=issue['self'],
             jira_key=issue['key'],
@@ -28,38 +42,63 @@ def create_issue(data):
             iss_updated=parser.parse(issue['fields']['updated']),
             iss_created=parser.parse(issue['fields']['created']),
         )
+        logger.info("Created issue %s", created_issue.jira_key)
+    else:
+        logger.info("No configuration for project %s, skipping issue %s",
+                    project_key, issue['fields']['issuetype']['id'])
     return HttpResponse('OK')
 
 
 def update_issue(data):
-    logger.error(data)
     issue = data['issue']
-    project = Project.objects.get(key=issue['fields']['project']['key'])
+    project_key = issue['fields']['project']['key']
+    # Use filter because we don't want the exception if get fails
+    project = Project.objects.filter(key=issue['fields']['project']['key']).first()
     if project:
-        issue_type = IssueType.objects.get(
-            jid=issue['fields']['issuetype']['id'],
-            project=project.id,
-        )
-        Issue.objects.filter(
-            jid=issue['id'],
-            project=project,
-        ).update(
-            link=issue['self'],
-            jira_key=issue['key'],
-            fixVersions=issue['fields']['fixVersions'],
-            summary=issue['fields']['summary'],
-            assignee=issue['fields']['assignee'],
-            issue_type=issue_type,
-            iss_updated=parser.parse(issue['fields']['updated']),
-            iss_created=parser.parse(issue['fields']['created']),
-        )
+        issue_type = _get_issue_type(issue, project)
+        if not issue_type:
+            logger.info("%s not configured to save IssueType %s",
+                        project_key, issue['fields']['issuetype']['name'])
+            return HttpResponse('OK')
+        # Create the issue if the create webhook missed it.  This can happen in the case of an issue
+        # changing from a type we don't care about to one we do.
+        issue_qs = Issue.objects.filter(jid=issue['id'], project=project)
+        if len(issue_qs) == 0:
+            Issue.objects.create(
+                jid=issue['id'],
+                link=issue['self'],
+                jira_key=issue['key'],
+                fixVersions=issue['fields']['fixVersions'],
+                summary=issue['fields']['summary'],
+                assignee=issue['fields']['assignee'],
+                issue_type=issue_type,
+                project=project,
+                iss_updated=parser.parse(issue['fields']['updated']),
+                iss_created=parser.parse(issue['fields']['created']),
+            )
+            logger.info("Issue %s created", issue['key'])
+        else:
+            Issue.objects.filter(jid=issue['id'], project=project).update(
+                link=issue['self'],
+                jira_key=issue['key'],
+                fixVersions=issue['fields']['fixVersions'],
+                summary=issue['fields']['summary'],
+                assignee=issue['fields']['assignee'],
+                issue_type=issue_type,
+                iss_updated=parser.parse(issue['fields']['updated']),
+                iss_created=parser.parse(issue['fields']['created']),
+            )
+            logger.info("Issue %s updated", issue['key'])
+    else:
+        logger.info("No configuration for project %s, skipping issue %s",
+                    project_key, issue['fields']['issuetype']['id'])
     return HttpResponse('OK')
 
 
 def delete_issue(data):
-    logger.error(data)
     issue = data['issue']
-    project = Project.objects.get(key=issue['fields']['project']['key'])
+    # Use filter because we don't want the exception if get fails
+    project = Project.objects.filter(key=issue['fields']['project']['key']).first()
     if project:
         issue_type = IssueType.objects.get(
             jid=issue['fields']['issuetype']['id'],
@@ -82,5 +121,5 @@ def delete_issue(data):
 
 
 register(create_issue, 'jira:issue_created')
-register(update_issue,'jira:issue_updated')
+register(update_issue, 'jira:issue_updated')
 register(delete_issue, 'jira:issue_deleted')

--- a/tcms/templates/issues/issue_not_found.html
+++ b/tcms/templates/issues/issue_not_found.html
@@ -1,0 +1,10 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <link rel="stylesheet" href="https://unpkg.com/@atlaskit/css-reset@2.0.0/dist/bundle.css" media="all">
+        <script src="https://connect-cdn.atl-paas.net/all.js" async></script>
+    </head>
+    <body>
+    <h4>Issue not found, please check Kiwi configuration.</h4>
+    </body>
+</html>


### PR DESCRIPTION
- Add missing tests for webhooks
- Gracefully handle jira view when issue does not exist
- Create issue on update if it does not exist
- Handle unconfigured projects and issuetypes better in the webhooks
- Prevent server errors when slack is not configured